### PR TITLE
feat(journey): embed Explore into Journey hub (iframe)

### DIFF
--- a/journey.html
+++ b/journey.html
@@ -123,7 +123,11 @@
     </section>
 
     <section id="sec-explore" class="section">
-      <div class="card"><h2>Explore</h2><p class="muted">For full search and filters, open Explore. We will embed this here in a later step.</p><div class="actions"><a class="btn" href="explore.html">Open Explore</a></div></div>
+      <div class="card">
+        <h2>Explore</h2>
+        <p class="muted">Search occupations, training, apprenticeships, and local help — add items to your plan.</p>
+        <iframe id="exploreFrame" src="explore.html" style="width:100%;height:85vh;border:1px solid #e5e7eb;border-radius:12px;"></iframe>
+      </div>
     </section>
 
     <section id="sec-plan" class="section">
@@ -221,4 +225,3 @@
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
Embeds Explore (explore.html) inside the Journey hub Explore tab for a smoother in-page experience.\n\nChanges\n- journey.html: replace Explore link card with an iframe pointing to explore.html (85vh), keeping consistent card framing\n- No impact to Explore standalone; aggregator-backed results still work when configured\n\nFuture\n- Optionally modularize Explore UI to render directly without iframe\n- Add tenant toggle for CCR vs Year 13/14 naming in hub settings