### PR TITLE
fix(RIASEC): visible Quick Picks + accessible chips

### DIFF
--- a/assessments.html
+++ b/assessments.html
@@ -44,8 +44,10 @@
         .spaced { margin-top: 8px; }
         .right { display:flex; gap:8px; justify-content:flex-end; }
         .danger { background:#ef4444; }
-        /* Teen-friendly chips */
-        .chip { display:inline-flex; align-items:center; gap:6px; padding:8px 12px; border-radius:999px; border:1px solid #e5e7eb; background:#fff; cursor:pointer; }
+        /* Teen-friendly chips (override button default color for readability) */
+        .chip { display:inline-flex; align-items:center; gap:6px; padding:8px 12px; border-radius:999px; border:1px solid #e5e7eb; background:#fff; color:#111827; cursor:pointer; }
+        .chip:focus-visible { outline: 2px solid #0ea5e9; outline-offset: 2px; }
+        .chip.active { background:#111827; color:#fff; border-color:#111827; }
         .chip:hover { box-shadow:0 2px 10px rgba(0,0,0,0.06); transform: translateY(-1px); }
         /* Pill FAB (feedback/chat) */
         .fab-pill { position: fixed; right: calc(20px + env(safe-area-inset-right)); bottom: calc(20px + env(safe-area-inset-bottom)); background: linear-gradient(135deg,#BD0934,#FFC838); color:#fff; border:none; border-radius:999px; padding:12px 16px; font-weight:700; box-shadow:0 8px 24px rgba(0,0,0,0.25); cursor:pointer; z-index: 1200; }


### PR DESCRIPTION
Quick fix to make the RIASEC "Quick Picks" buttons (Tech Curious, Helper/Educator, Builder/Hands‑on, Creative Content) readable and accessible.

Context
- Buttons were inheriting global `button` color `#fff` on a white chip background, making text invisible until hover.

Changes
- assessments.html CSS:
  - `.chip { color: #111827; background: #fff; }` to override global white text.
  - `.chip:focus-visible` outline for keyboard users.
  - `.chip.active` style for potential selection state.

Why
- Improves readability and accessibility in the RIASEC Interests section.
- Keeps existing visual style; no layout changes.

Test
- Open `assessments.html` → RIASEC Interests → Quick Picks row. Text should be visible without hover.
- Tab to a chip: focus ring is visible.

Notes
- CI runs compile check only; no JS changes.
- If desired, we can wire `.chip.active` toggling next.
